### PR TITLE
[FEAT] User 회원가입 기능 구현 (통합/E2E 테스트)

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Gender.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.user;
+
+public enum Gender {
+    M,
+    F
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -2,19 +2,43 @@ package com.loopers.domain.user;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
+@Entity
+@Table(name = "member")
+@Getter
 public class User {
 
-    private final String userId;
-    private final String name;
-    private final String email;
-    private final String birth;
+    @Id
+    private String userId;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private String email;
+
+    private String birth;
 
     private static final String PATTERN_USER_ID = "^[a-zA-Z0-9]{1,10}$";
     private static final String PATTERN_EMAIL = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     private static final String PATTERN_BIRTH = "^\\d{4}-\\d{2}-\\d{2}$";
 
-    public User(String userId, String name, String email, String birth) {
+    protected User() {}
+
+    public User(
+        String userId,
+        String name,
+        Gender gender,
+        String email,
+        String birth
+    ) {
         if (userId == null || !userId.matches(PATTERN_USER_ID)) {
             throw new CoreException(
                 ErrorType.BAD_REQUEST,
@@ -36,8 +60,13 @@ public class User {
             );
         }
 
+        if (gender == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 필수 입력값입니다.");
+        }
+
         this.userId = userId;
         this.name = name;
+        this.gender = gender;
         this.email = email;
         this.birth = birth;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.user;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository {
+
+    User save(User user);
+
+    boolean existsByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User signUp(
+        String userId,
+        String name,
+        Gender gender,
+        String email,
+        String birth
+    ) {
+        if (userRepository.existsByUserId(userId)) {
+            throw new CoreException(ErrorType.CONFLICT,
+                "[userId = " + userId + "] 이미 존재하는 사용자 ID입니다.");
+        }
+
+        User user = new User(userId, name, gender, email, birth);
+        return userRepository.save(user);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, String> {
+
+    boolean existsByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByUserId(String userId) {
+        return userJpaRepository.existsByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -5,20 +5,20 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 @Slf4j
@@ -43,6 +43,15 @@ public class ApiControllerAdvice {
         String name = e.getParameterName();
         String type = e.getParameterType();
         String message = String.format("필수 요청 파라미터 '%s' (타입: %s)가 누락되었습니다.", name, type);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentNotValidException e) {
+        String fieldName = e.getBindingResult().getFieldErrors().getFirst().getField();
+        String rejectedValue = String.valueOf(e.getBindingResult().getFieldErrors().getFirst().getRejectedValue());
+        String defaultMessage = e.getBindingResult().getFieldErrors().getFirst().getDefaultMessage();
+        String message = String.format("필수 필드 '%s'의 값 '%s'이(가) 유효하지 않습니다: %s", fieldName, rejectedValue, defaultMessage);
         return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,14 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "Loopers 사용자 API 입니다.")
+public interface UserV1ApiSpec {
+
+    @Operation(summary = "회원 가입")
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+        UserV1Dto.SignUpRequest signUpRequest
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,64 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto.GenderResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1Controller implements UserV1ApiSpec{
+
+    private final UserService userService;
+
+    public UserV1Controller(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> signUp(
+        @Valid @RequestBody UserV1Dto.SignUpRequest signUpRequest
+    ) {
+
+        Gender gender = convertGender(signUpRequest.gender());
+
+        User user = userService.signUp(
+            signUpRequest.userId(),
+            signUpRequest.name(),
+            gender,
+            signUpRequest.email(),
+            signUpRequest.birth()
+        );
+
+        UserV1Dto.UserResponse response = new UserV1Dto.UserResponse(
+            user.getUserId(),
+            user.getName(),
+            convvertGenderResponse(user.getGender()),
+            user.getBirth(),
+            user.getEmail()
+        );
+
+        return ApiResponse.success(response);
+    }
+
+    private Gender convertGender(UserV1Dto.SignUpRequest.GenderRequest genderRequest) {
+        return switch (genderRequest) {
+            case M -> Gender.M;
+            case F -> Gender.F;
+        };
+    }
+
+    private UserV1Dto.GenderResponse convvertGenderResponse(Gender gender) {
+        return switch (gender) {
+            case M -> GenderResponse.M;
+            case F -> GenderResponse.F;
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,38 @@
+package com.loopers.interfaces.api.user;
+
+import jakarta.validation.constraints.NotNull;
+
+public class UserV1Dto {
+    public record SignUpRequest(
+        @NotNull
+        String userId,
+        @NotNull
+        String name,
+        @NotNull
+        GenderRequest gender,
+        @NotNull
+        String birth,
+        @NotNull
+        String email
+    ) {
+
+        enum GenderRequest {
+            M,
+            F
+        }
+    }
+
+    public record UserResponse(
+        String userId,
+        String name,
+        GenderResponse gender,
+        String birth,
+        String email
+    ) { }
+
+    enum GenderResponse {
+        M,
+        F
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.loopers.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest
+public class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @MockitoSpyBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("회원 가입시 User 저장이 수행된다.")
+    void saveUser_whenSignUpIsSuccessful() {
+        // given
+        String userId = "soo";
+        String name = "박수호";
+        Gender gender = Gender.M;
+        String email = "abc@gmail.com";
+        String birth = "1995-03-01";
+
+        // when
+        User result = userService.signUp(userId, name, gender, email, birth);
+
+        // then
+        verify(userRepository, times(1)).existsByUserId(userId);
+        verify(userRepository, times(1)).save(any(User.class));
+
+        assertAll(
+            () -> assertThat(result).isNotNull(),
+            () -> assertThat(result.getUserId()).isEqualTo(userId),
+            () -> assertThat(result.getName()).isEqualTo(name),
+            () -> assertThat(result.getGender()).isEqualTo(gender),
+            () -> assertThat(result.getEmail()).isEqualTo(email),
+            () -> assertThat(result.getBirth()).isEqualTo(birth)
+        );
+    }
+
+    @Test
+    @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")
+    void fail_whenUserIdAlreadyExists() {
+
+        // given
+        String existingUserId = "existUser";
+        String name = "박수호";
+        Gender gender = Gender.M;
+        String email = "abc@gmail.com";
+        String birth = "1995-03-01";
+
+        userService.signUp(existingUserId, name, gender, email, birth);
+
+        // when & then
+        assertThatThrownBy(() -> userService.signUp(existingUserId, name, gender, email, birth))
+            .isInstanceOf(CoreException.class)
+            .satisfies(exception -> {
+                CoreException coreException = (CoreException) exception;
+                assertThat(coreException.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+                assertThat(coreException.getMessage()).isEqualTo("[userId = " + existingUserId + "] 이미 존재하는 사용자 ID입니다.");
+            });
+
+        verify(userRepository, times(2)).existsByUserId(existingUserId);
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.user;
 
 
+import static com.loopers.domain.user.Gender.M;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,10 +24,11 @@ class UserTest {
     })
     void fail_whenIdFormatIsInvalid(String userId) {
         String name = "박수호";
+        Gender gender = M;
         String email = "abc@gmail.com";
         String birth = "1995-03-01";
 
-        assertThatThrownBy(() -> new User(userId, name, email, birth))
+        assertThatThrownBy(() -> new User(userId, name, gender, email, birth))
             .isInstanceOf(CoreException.class)
             .satisfies(exception -> {
                 CoreException coreException = (CoreException) exception;
@@ -40,10 +42,11 @@ class UserTest {
     void fail_whenEmailFormatIsInvalid() {
         String userId = "clap";
         String name = "박수호";
+        Gender gender = M;
         String invalidEmail = "abc.gmail@com";
         String birth = "1995-03-01";
 
-        assertThatThrownBy(() -> new User(userId, name, invalidEmail, birth))
+        assertThatThrownBy(() -> new User(userId, name, gender, invalidEmail, birth))
             .isInstanceOf(CoreException.class)
             .satisfies(exception -> {
                 CoreException coreException = (CoreException) exception;
@@ -57,10 +60,11 @@ class UserTest {
     void fail_whenBirthDateFormatIsInvalid() {
         String userId = "clap";
         String name = "박수호";
+        Gender gender = M;
         String email = "abc@gmail.com";
         String birth = "1995.03.01";
 
-        assertThatThrownBy(() -> new User(userId, name, email, birth))
+        assertThatThrownBy(() -> new User(userId, name, gender, email, birth))
             .isInstanceOf(CoreException.class)
             .satisfies(exception -> {
                 CoreException coreException = (CoreException) exception;

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,85 @@
+package com.loopers.interfaces.api.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto.GenderResponse;
+import com.loopers.interfaces.api.user.UserV1Dto.SignUpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class UserV1ApiE2ETest {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Join {
+
+        private static final String ENDPOINT = "/api/v1/users";
+
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInfo_whenJoinIsSuccessful() {
+            //arrange
+            UserV1Dto.SignUpRequest signUpRequest = new SignUpRequest(
+                "clap",
+                "박수호",
+                UserV1Dto.SignUpRequest.GenderRequest.M,
+                "1995-03-01",
+                "abc@gmail.com"
+            );
+
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+            //assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().data().name()).isEqualTo(signUpRequest.name()),
+                () -> assertThat(response.getBody().data().gender()).isEqualTo(GenderResponse.M)
+            );
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenGenderIsMissing() {
+            //arrange
+            UserV1Dto.SignUpRequest signUpRequest = new SignUpRequest(
+                "clap",
+                "박수호",
+                null,
+                "1995-03-01",
+                "abc@gmail.com"
+            );
+
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+            //assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL),
+                () -> assertThat(response.getBody().data()).isNull()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary

- 회원가입 기능 구현
- User 서비스 통합테스트 작성
- User API 레이어 E2E 테스트 작성

## 💬 Review Points

- spy()를 적절하게 테스트에 사용했는지 궁금합니다.
- Gender enum을 일단 간단하게 작성해놓았는데 어떤식으로 사용할지 조언 부탁드립니다. 
- API 레이어에서 Domain 레이어를 의존하고 있는데, 과제를 마무리한 후 리팩토링 할 예정입니다.


## ✅ Checklist

**통합 테스트**

- [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**E2E 테스트**

- [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.
