### PR TITLE
[FEAT] 포인트 조회 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.point;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "point")
+@Getter
+public class Point {
+    @Id
+    private String userId;
+    private Long amount;
+
+    protected Point() {}
+
+    public Point(String userId) {
+        this.userId = userId;
+        this.amount = 0L;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.point;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointRepository {
+
+    Point findByUserId(String userId);
+
+    Point save(Point point);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Long getPointAmount(String userId) {
+        if (!userRepository.existsByUserId(userId)) {
+            return null;
+        }
+
+        Point point = pointRepository.findByUserId(userId);
+
+        if (point == null) {
+            throw new CoreException(ErrorType.NOT_FOUND,
+                "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다."
+            );
+        }
+
+        return point.getAmount();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.user;
 
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PointRepository pointRepository;
 
     @Transactional
     public User signUp(
@@ -26,6 +29,9 @@ public class UserService {
         }
 
         User user = new User(userId, name, gender, email, birth);
+        Point point = new Point(userId);
+        pointRepository.save(point);
+
         return userRepository.save(user);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.Point;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointJpaRepository extends JpaRepository<Point, String> {
+
+    Optional<Point> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointRepositoryImpl implements PointRepository {
+
+    private final PointJpaRepository pointJpaRepository;
+
+    @Override
+    public Point findByUserId(String userId) {
+        return pointJpaRepository.findByUserId(userId).orElse(null);
+    }
+
+    @Override
+    public Point save(Point point) {
+        return pointJpaRepository.save(point);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -35,6 +36,13 @@ public class ApiControllerAdvice {
         String type = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";
         String value = e.getValue() != null ? e.getValue().toString() : "null";
         String message = String.format("요청 파라미터 '%s' (타입: %s)의 값 '%s'이(가) 잘못되었습니다.", name, type, value);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String headerName = e.getHeaderName();
+        String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", headerName);
         return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Point V1 API", description = "사용자 Point API 입니다.")
+public interface PointV1ApiSpec {
+
+    @Operation(summary = "포인트 조회")
+    ApiResponse<PointV1Dto.PointResponse> getPoint(
+        @RequestHeader("X-USER-ID") String userId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.domain.point.PointService;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.point.PointV1Dto.PointResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/points")
+@RequiredArgsConstructor
+public class PointV1Controller implements PointV1ApiSpec{
+
+    private final PointService pointService;
+
+    @GetMapping
+    @Override
+    public ApiResponse<PointResponse> getPoint(@RequestHeader ("X-USER-ID") String userId) {
+
+        Long amount = pointService.getPointAmount(userId);
+
+        if (amount == null) {
+            throw new CoreException(ErrorType.NOT_FOUND,
+                "[userId = " + userId + "] 사용자를 찾을 수 없습니다.");
+        }
+
+        return ApiResponse.success(new PointResponse(amount));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,6 @@
+package com.loopers.interfaces.api.point;
+
+public class PointV1Dto {
+
+    public record PointResponse(Long amount) {}
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.loopers.domain.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.domain.user.UserService;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest
+public class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private UserService userService;
+
+    @MockitoSpyBean
+    private PointRepository pointRepository;
+
+    @MockitoSpyBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트 조회")
+    @Nested
+    class Get {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsPointAmount_whenUserExists() {
+            //given
+            String userId = "exist";
+            userService.signUp(
+                userId,
+                "성공",
+                Gender.M,
+                "abc@gmail.com",
+                "2000-01-01"
+            );
+
+            //when
+            Long point = pointService.getPointAmount(userId);
+
+            //then
+            verify(pointRepository, times(1)).findByUserId(userId);
+            assertThat(point).isEqualTo(0L);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnsNull_whenUserNotExists() {
+            //given
+            String userId = "notexist";
+
+            //when
+            Long point = pointService.getPointAmount(userId);
+
+            //then
+            verify(userRepository, times(1)).existsByUserId(userId);
+            verify(pointRepository, never()).findByUserId(userId);
+            assertThat(point).isNull();
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,100 @@
+package com.loopers.interfaces.api.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class PointV1ApiE2ETest {
+
+    private static final String ENDPOINT = "/api/v1/points";
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("GET /api/v1/points")
+    @Nested
+    class Find {
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPointAmount_whenUserExists() {
+            //given
+            String userId = "exist";
+
+            userService.signUp(
+                userId,
+                "성공",
+                Gender.M,
+                "abcde@gmail.com",
+                "1995-03-02"
+            );
+
+            //when
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+            HttpEntity<?> requestEntity = new HttpEntity<>(headers);
+
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
+                new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, requestEntity, responseType);
+
+            //then
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS),
+                () -> assertThat(response.getBody().data()).isNotNull(),
+                () -> assertThat(response.getBody().data().amount()).isEqualTo(0L)
+            );
+        }
+
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenUserIdHeaderMissing() {
+            //when
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
+                new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, null, responseType);
+
+            //then
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL),
+                () -> assertThat(response.getBody().data()).isNull()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- 포인트 조회 기능 구현
- 통합테스트 및 E2E 테스트 작성
- 회원가입 시 포인트 계정 자동 생성

## 💬 Review Points

### E2E 테스트의 헤더 검증 범위

요구사항 "X-USER-ID 헤더가 없을 경우"에 대해 현재는 헤더 자체를 전송하지 않는 케이스만 테스트했습니다. 
다른 헤더는 있지만 X-USER-ID만 없는 경우나 빈 값인 경우도 추가 테스트가 필요할까요?

## ✅ Checklist

**통합 테스트**
- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**E2E 테스트**
- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
