### PR TITLE
[FIX] X-USER-ID 헤더 검증 로직 개선

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -25,6 +25,10 @@ public class PointV1Controller implements PointV1ApiSpec{
     @Override
     public ApiResponse<PointResponse> getPoint(@RequestHeader ("X-USER-ID") String userId) {
 
+        if (userId == null || userId.trim().isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 값이 비어있습니다.");
+        }
+
         Long amount = pointService.getPointAmount(userId);
 
         if (amount == null) {
@@ -41,6 +45,10 @@ public class PointV1Controller implements PointV1ApiSpec{
         @RequestHeader("X-USER-ID") String userId,
         @RequestBody ChargeRequest chargeRequest
     ) {
+        if (userId == null || userId.trim().isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 값이 비어있습니다.");
+        }
+
         Long totalAmount = pointService.chargePoint(userId, chargeRequest.amount());
         return ApiResponse.success(new PointResponse(totalAmount));
     }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -82,11 +82,17 @@ public class PointV1ApiE2ETest {
         @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
         @Test
         void returnsBadRequest_whenUserIdHeaderMissing() {
+            //given
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Content-Type", "application/json");
+            headers.set("Accept", "application/json");
+            HttpEntity<?> requestEntity = new HttpEntity<>(headers);
+
             //when
             ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
                 new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
-                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, null, responseType);
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, requestEntity, responseType);
 
             //then
             assertAll(


### PR DESCRIPTION
## 작업 내용

- 헤더가 없는 경우 검증 -> X-USER-ID 헤더 누락인 케이스 검증으로 변경
- X-USER-ID 빈값으로 넘어오는 경우 예외처리