### PR TITLE
[round-4] 재고/포인트/쿠폰 동시성 이슈 제어

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -23,10 +23,10 @@ public class LikeFacade {
     public LikeInfo.Like addLike(LikeCommand.Add command) {
         validateLikeCommand(command.userId(), command.productId());
 
-        boolean alreadyLiked = likeService.isLikedByUser(command.userId(), command.productId());
+        boolean alreadyLiked = likeService.isLiked(command.userId(), command.productId());
 
         if (!alreadyLiked) {
-            likeService.create(command.userId(), command.productId());
+            likeService.like(command.userId(), command.productId());
         }
 
         return buildLikeInfo(command.productId(), true);
@@ -36,10 +36,10 @@ public class LikeFacade {
     public LikeInfo.Like removeLike(LikeCommand.Remove command) {
         validateLikeCommand(command.userId(), command.productId());
 
-        boolean currentlyLiked = likeService.isLikedByUser(command.userId(), command.productId());
+        boolean currentlyLiked = likeService.isLiked(command.userId(), command.productId());
 
         if (currentlyLiked) {
-            likeService.delete(command.userId(), command.productId());
+            likeService.unlike(command.userId(), command.productId());
         }
 
         return buildLikeInfo(command.productId(), false);
@@ -51,14 +51,14 @@ public class LikeFacade {
     }
 
     private void validateUserExists(String userId) {
-        User user = userService.findByUserId(userId);
+        User user = userService.get(userId);
         if (user == null) {
             throw new CoreException(ErrorType.NOT_FOUND, "사용자가 존재하지 않습니다.");
         }
     }
 
     private Product validateProductExists(Long productId) {
-        Product product = productService.findById(productId);
+        Product product = productService.get(productId);
         if (product == null) {
             throw new CoreException(ErrorType.NOT_FOUND, "상품이 존재하지 않습니다.");
         }
@@ -66,7 +66,7 @@ public class LikeFacade {
     }
 
     private LikeInfo.Like buildLikeInfo(Long productId, boolean isLiked) {
-        long likeCount = likeService.countLikesByProduct(productId);
+        long likeCount = likeService.countByProduct(productId);
         return new LikeInfo.Like(productId, isLiked, likeCount);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -6,8 +6,13 @@ public class OrderCommand {
 
     public static record Create(
         String userId,
-        List<OrderItemCommand.Create> items
+        List<OrderItemCommand.Create> items,
+        Long couponId
     ) {
+
+        public Create(String userId, List<OrderItemCommand.Create> items) {
+            this(userId, items, null);
+        }
     }
 
     public static record GetDetail(

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.order.external.ExternalOrderService;
@@ -23,6 +25,7 @@ public class OrderFacade {
     private final UserService userService;
     private final PointService pointService;
     private final ExternalOrderService externalOrderService;
+    private final CouponService couponService;
 
     @Transactional
     public OrderInfo.Detail createOrder(OrderCommand.Create command) {
@@ -42,7 +45,12 @@ public class OrderFacade {
             );
         }
 
-        pointService.usePoint(command.userId(), order.getTotalPrice().getValue().longValue());
+        if (command.couponId() != null) {
+            Coupon coupon = couponService.getUserCoupon(command.couponId(), command.userId());
+            order.applyCoupon(coupon);
+        }
+
+        pointService.usePoint(command.userId(), order.getFinalPrice().getValue().longValue());
 
         Order savedOrder = orderService.save(order);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -23,24 +23,24 @@ public class ProductFacade {
 
     @Transactional(readOnly = true)
     public ProductInfo.Detail getProductDetail(ProductCommand.GetDetail command) {
-        Product product = productService.findById(command.productId());
+        Product product = productService.get(command.productId());
 
-        Brand brand = brandService.findById(product.getBrandId());
+        Brand brand = brandService.get(product.getBrandId());
 
-        long likeCount = likeService.countLikesByProduct(command.productId());
+        long likeCount = likeService.countByProduct(command.productId());
 
         return ProductInfo.Detail.from(product, brand, likeCount);
     }
 
     @Transactional(readOnly = true)
     public ProductInfo.PagedList getProducts(ProductCommand.GetList command) {
-        List<Product> products = productService.findProductsWithSortingAndPaging(
+        List<Product> products = productService.getAllWithSortingAndPaging(
             command.sort(),
             command.page(),
             command.size()
         );
 
-        long totalCount = productService.countProducts();
+        long totalCount = productService.count();
 
         List<ProductInfo.Detail> productDetails = products.stream()
             .map(this::buildProductDetail)
@@ -53,13 +53,13 @@ public class ProductFacade {
     public ProductInfo.PagedList getLikedProducts(ProductCommand.GetLikedProducts command) {
         validateUserExists(command.userId());
 
-        List<Like> likes = likeService.findLikesByUserIdWithPaging(
+        List<Like> likes = likeService.getAllByUserWithPaging(
             command.userId(),
             command.page(),
             command.size()
         );
 
-        long totalCount = likeService.countLikesByUser(command.userId());
+        long totalCount = likeService.countByUser(command.userId());
 
         List<ProductInfo.Detail> productDetails = likes.stream()
             .map(this::buildLikedProductDetail)
@@ -69,23 +69,23 @@ public class ProductFacade {
     }
 
     private void validateUserExists(String userId) {
-        userService.findByUserId(userId);
+        userService.get(userId);
     }
 
     private ProductInfo.Detail buildProductDetail(Product product) {
-        Brand brand = brandService.findById(product.getBrandId());
+        Brand brand = brandService.get(product.getBrandId());
 
-        long likeCount = likeService.countLikesByProduct(product.getId());
+        long likeCount = likeService.countByProduct(product.getId());
 
         return ProductInfo.Detail.from(product, brand, likeCount);
     }
 
     private ProductInfo.Detail buildLikedProductDetail(Like like) {
-        Product product = productService.findById(like.getProductId());
+        Product product = productService.get(like.getProductId());
 
-        Brand brand = brandService.findById(product.getBrandId());
+        Brand brand = brandService.get(product.getBrandId());
 
-        long likeCount = likeService.countLikesByProduct(product.getId());
+        long likeCount = likeService.countByProduct(product.getId());
 
         return ProductInfo.Detail.from(product, brand, likeCount);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -16,7 +16,7 @@ public class BrandService {
         return brandRepository.save(brand);
     }
 
-    public Brand findById(Long id) {
+    public Brand get(Long id) {
         Brand brand = brandRepository.findById(id);
 
         if (brand == null) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,134 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.product.Money;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "coupon")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "coupon_type", discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CouponStatus status;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "min_order_amount"))
+    private Money minOrderAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    private LocalDateTime usedAt;
+
+    protected Coupon(
+        String name,
+        String userId,
+        Money minOrderAmount,
+        LocalDateTime expiredAt
+    ) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "쿠폰명은 필수입니다."
+            );
+        }
+
+        if (userId == null || userId.trim().isEmpty()) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "User ID는 필수입니다."
+            );
+        }
+
+        if (expiredAt == null || expiredAt.isBefore(LocalDateTime.now())) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "만료일은 현재 시간 이후여야 합니다."
+            );
+        }
+
+        this.name = name;
+        this.userId = userId;
+        this.status = CouponStatus.ACTIVE;
+        this.minOrderAmount = minOrderAmount;
+        this.createdAt = LocalDateTime.now();
+        this.expiredAt = expiredAt;
+    }
+
+    public abstract Money calculateDiscountAmount(Money orderAmount);
+
+    public abstract CouponType getType();
+
+    public void use(Money orderAmount) {
+        if (status == CouponStatus.USED) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "이미 사용된 쿠폰입니다."
+            );
+        }
+
+        if (status != CouponStatus.ACTIVE) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "사용할 수 없는 쿠폰입니다."
+            );
+        }
+
+        if (LocalDateTime.now().isAfter(expiredAt)) {
+            this.status = CouponStatus.EXPIRED;
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "만료된 쿠폰입니다."
+            );
+        }
+
+        if (orderAmount.getValue().compareTo(minOrderAmount.getValue()) < 0) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                String.format(
+                    "최소 주문 금액 %s원 이상이어야 쿠폰을 사용할 수 있습니다.",
+                    minOrderAmount.getValue()
+                )
+            );
+        }
+
+        this.status = CouponStatus.USED;
+        this.usedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -55,6 +56,9 @@ public abstract class Coupon {
     private LocalDateTime expiredAt;
 
     private LocalDateTime usedAt;
+
+    @Version
+    private Long version;
 
     protected Coupon(
         String name,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+
+    Coupon save(Coupon coupon);
+
+    Optional<Coupon> findById(Long id);
+
+    Optional<Coupon> findByIdAndUserId(Long id, String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -17,7 +17,7 @@ public class CouponService {
     @Transactional
     public Money apply(Long couponId, String userId, Money orderAmount) {
         try {
-            Coupon coupon = getUserCoupon(couponId, userId);
+            Coupon coupon = get(couponId, userId);
 
             Money discountAmount = coupon.calculateDiscountAmount(orderAmount);
 
@@ -33,7 +33,7 @@ public class CouponService {
         }
     }
 
-    public Coupon getUserCoupon(Long couponId, String userId) {
+    public Coupon get(Long couponId, String userId) {
         return couponRepository.findByIdAndUserId(couponId, userId)
             .orElseThrow(() -> new CoreException(
                 ErrorType.NOT_FOUND,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,35 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.product.Money;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public Money apply(Long couponId, String userId, Money orderAmount) {
+        Coupon coupon = getUserCoupon(couponId, userId);
+
+        Money discountAmount = coupon.calculateDiscountAmount(orderAmount);
+
+        coupon.use(orderAmount);
+        couponRepository.save(coupon);
+
+        return discountAmount;
+    }
+
+    private Coupon getUserCoupon(Long couponId, String userId) {
+        return couponRepository.findByIdAndUserId(couponId, userId)
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
+                "사용자의 쿠폰을 찾을 수 없습니다."
+            ));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -33,7 +33,7 @@ public class CouponService {
         }
     }
 
-    private Coupon getUserCoupon(Long couponId, String userId) {
+    public Coupon getUserCoupon(Long couponId, String userId) {
         return couponRepository.findByIdAndUserId(couponId, userId)
             .orElseThrow(() -> new CoreException(
                 ErrorType.NOT_FOUND,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponStatus.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public enum CouponStatus {
+    ACTIVE("활성"),
+    USED("사용됨"),
+    EXPIRED("만료됨");
+
+    private final String description;
+
+    CouponStatus(String description) {
+        this.description = description;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponType.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public enum CouponType {
+    FIXED_AMOUNT("정액 할인"),
+    FIXED_RATE("정률 할인");
+
+    private final String description;
+
+    CouponType(String description) {
+        this.description = description;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountAmount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountAmount.java
@@ -1,0 +1,55 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscountAmount {
+
+    @Column(name = "discount_amount", precision = 19, scale = 2)
+    private BigDecimal amount;
+
+    private DiscountAmount(BigDecimal amount) {
+        if (amount == null) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "할인 금액은 필수입니다."
+            );
+        }
+
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "할인 금액은 0 이상이어야 합니다."
+            );
+        }
+
+        this.amount = amount;
+    }
+
+    public static DiscountAmount of(BigDecimal amount) {
+        return new DiscountAmount(amount);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        DiscountAmount that = (DiscountAmount) obj;
+        return amount.compareTo(that.amount) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return amount.hashCode();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountRate.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountRate.java
@@ -1,0 +1,57 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscountRate {
+
+    @Column(name = "discount_rate", precision = 19, scale = 2)
+    private BigDecimal rate;
+
+    private DiscountRate(BigDecimal rate) {
+        if (rate == null) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "할인률은 필수입니다."
+            );
+        }
+
+        if (rate.compareTo(BigDecimal.ZERO) < 0 ||
+            rate.compareTo(BigDecimal.valueOf(100)) > 0
+        ) {
+            throw new CoreException(
+                ErrorType.BAD_REQUEST,
+                "할인률은 0에서 100 사이여야 합니다."
+            );
+        }
+
+        this.rate = rate;
+    }
+
+    public static DiscountRate of(BigDecimal rate) {
+        return new DiscountRate(rate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        DiscountRate that = (DiscountRate) obj;
+        return rate.compareTo(that.rate) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return rate.hashCode();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountCoupon.java
@@ -1,0 +1,57 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.product.Money;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("FIXED_AMOUNT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FixedAmountCoupon extends Coupon{
+
+    @Embedded
+    private DiscountAmount discountAmount;
+
+    private FixedAmountCoupon(
+        String name,
+        String userId,
+        DiscountAmount discountAmount,
+        Money minOrderAmount,
+        LocalDateTime expiredAt
+    ) {
+        super(name, userId, minOrderAmount, expiredAt);
+        this.discountAmount = discountAmount;
+    }
+
+    public static FixedAmountCoupon create(
+        String name,
+        String userId,
+        DiscountAmount discountAmount,
+        Money minOrderAmount,
+        LocalDateTime expiredAt
+    ) {
+        return new FixedAmountCoupon(
+            name,
+            userId,
+            discountAmount,
+            minOrderAmount,
+            expiredAt
+        );
+    }
+
+    @Override
+    public Money calculateDiscountAmount(Money orderAmount) {
+        return Money.of(discountAmount.getAmount());
+    }
+
+    @Override
+    public CouponType getType() {
+        return CouponType.FIXED_AMOUNT;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedRateCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedRateCoupon.java
@@ -1,0 +1,79 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.product.Money;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("FIXED_RATE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FixedRateCoupon extends Coupon {
+
+    @Embedded
+    private DiscountRate discountRate;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "max_discount_amount"))
+    private Money maxDiscountAmount;
+
+    private FixedRateCoupon(
+        String name,
+        String userId,
+        DiscountRate discountRate,
+        Money maxDiscountAmount,
+        Money minOrderAmount,
+        LocalDateTime expiredAt
+    ) {
+        super(name, userId, minOrderAmount, expiredAt);
+        this.discountRate = discountRate;
+        this.maxDiscountAmount = maxDiscountAmount;
+    }
+
+    public static FixedRateCoupon create(
+        String name,
+        String userId,
+        DiscountRate discountRate,
+        Money maxDiscountAmount,
+        Money minOrderAmount,
+        LocalDateTime expiredAt
+    ) {
+        return new FixedRateCoupon(
+            name,
+            userId,
+            discountRate,
+            maxDiscountAmount,
+            minOrderAmount,
+            expiredAt
+        );
+    }
+
+    @Override
+    public Money calculateDiscountAmount(Money orderAmount) {
+        BigDecimal discountAmount = orderAmount.getValue()
+            .multiply(discountRate.getRate())
+            .divide(BigDecimal.valueOf(100), 2, RoundingMode.DOWN);
+
+        if (maxDiscountAmount != null &&
+            discountAmount.compareTo(maxDiscountAmount.getValue()) > 0
+        ) {
+            return maxDiscountAmount;
+        }
+
+        return Money.of(discountAmount);
+    }
+
+    @Override
+    public CouponType getType() {
+        return CouponType.FIXED_RATE;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -12,7 +12,7 @@ public class LikeService {
     private final LikeRepository likeRepository;
 
     @Transactional
-    public Like create(String userId, Long productId) {
+    public Like like(String userId, Long productId) {
         Like existingLike = likeRepository.findByUserIdAndProductId(userId, productId);
         if (existingLike != null) {
             return existingLike;
@@ -23,27 +23,27 @@ public class LikeService {
     }
 
     @Transactional
-    public void delete(String userId, Long productId) {
+    public void unlike(String userId, Long productId) {
         likeRepository.deleteByUserIdAndProductId(userId, productId);
     }
 
-    public List<Like> findLikesByUser(String userId) {
+    public List<Like> getAllByUser(String userId) {
         return likeRepository.findByUserId(userId);
     }
 
-    public long countLikesByProduct(Long productId) {
-        return likeRepository.countByProductId(productId);
+    public List<Like> getAllByUserWithPaging(String userId, int page, int size) {
+        return likeRepository.findLikesByUserIdWithPaging(userId, page, size);
     }
 
-    public boolean isLikedByUser(String userId, Long productId) {
+    public boolean isLiked(String userId, Long productId) {
         return likeRepository.existsByUserIdAndProductId(userId, productId);
     }
 
-    public long countLikesByUser(String userId) {
-        return likeRepository.countByUserId(userId);
+    public long countByProduct(Long productId) {
+        return likeRepository.countByProductId(productId);
     }
 
-    public List<Like> findLikesByUserIdWithPaging(String userId, int page, int size) {
-        return likeRepository.findLikesByUserIdWithPaging(userId, page, size);
+    public long countByUser(String userId) {
+        return likeRepository.countByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -3,6 +3,7 @@ package com.loopers.domain.like;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -10,6 +11,7 @@ public class LikeService {
 
     private final LikeRepository likeRepository;
 
+    @Transactional
     public Like create(String userId, Long productId) {
         Like existingLike = likeRepository.findByUserIdAndProductId(userId, productId);
         if (existingLike != null) {
@@ -20,6 +22,7 @@ public class LikeService {
         return likeRepository.save(like);
     }
 
+    @Transactional
     public void delete(String userId, Long productId) {
         likeRepository.deleteByUserIdAndProductId(userId, productId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -2,10 +2,9 @@ package com.loopers.domain.order;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -13,11 +12,11 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
 
-    public Order save(Order order) {
+    public Order place(Order order) {
         return orderRepository.save(order);
     }
 
-    public Order findById(Long id) {
+    public Order get(Long id) {
         Order order = orderRepository.findById(id);
 
         if (order == null) {
@@ -30,7 +29,7 @@ public class OrderService {
         return order;
     }
 
-    public Order findByIdAndUserId(Long orderId, String userId) {
+    public Order get(Long orderId, String userId) {
         Order order = orderRepository.findByIdAndUserId(orderId, userId);
 
         if (order == null) {
@@ -43,7 +42,7 @@ public class OrderService {
         return order;
     }
 
-    public List<Order> findByUserId(String userId) {
+    public List<Order> getAllByUser(String userId) {
         return orderRepository.findByUserIdOrderByOrderedAtDesc(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,11 +1,14 @@
 package com.loopers.domain.point;
 
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PointRepository {
 
-    Point findByUserId(String userId);
+    Optional<Point> findByUserId(String userId);
+
+    Optional<Point> findByUserIdWithLock(String userId);
 
     Point save(Point point);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -21,13 +21,11 @@ public class PointService {
             return null;
         }
 
-        Point point = pointRepository.findByUserId(userId);
-
-        if (point == null) {
-            throw new CoreException(ErrorType.NOT_FOUND,
+        Point point = pointRepository.findByUserId(userId)
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
                 "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다."
-            );
-        }
+            ));
 
         return point.getAmount();
     }
@@ -39,12 +37,11 @@ public class PointService {
                 "[userId = " + userId + "] 해당 유저가 존재하지 않습니다.");
         }
 
-        Point point = pointRepository.findByUserId(userId);
-
-        if (point == null) {
-            throw new CoreException(ErrorType.NOT_FOUND,
-                "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다.");
-        }
+        Point point = pointRepository.findByUserIdWithLock(userId)
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
+                "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다."
+            ));
 
         point.charge(chargeAmount);
         pointRepository.save(point);
@@ -59,12 +56,11 @@ public class PointService {
                 "[userId = " + userId + "] 해당 유저가 존재하지 않습니다.");
         }
 
-        Point point = pointRepository.findByUserId(userId);
-
-        if (point == null) {
-            throw new CoreException(ErrorType.NOT_FOUND,
-                "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다.");
-        }
+        Point point = pointRepository.findByUserIdWithLock(userId)
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
+                "[userId = " + userId + "] 포인트 정보를 찾을 수 없습니다."
+            ));
 
         point.use(useAmount);
         pointRepository.save(point);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -16,7 +16,7 @@ public class PointService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public Long getPointAmount(String userId) {
+    public Long getAmount(String userId) {
         if (!userRepository.existsByUserId(userId)) {
             return null;
         }
@@ -31,7 +31,7 @@ public class PointService {
     }
 
     @Transactional
-    public Long chargePoint(String userId, Long chargeAmount) {
+    public Long charge(String userId, Long chargeAmount) {
         if (!userRepository.existsByUserId(userId)) {
             throw new CoreException(ErrorType.NOT_FOUND,
                 "[userId = " + userId + "] 해당 유저가 존재하지 않습니다.");
@@ -50,7 +50,7 @@ public class PointService {
     }
 
     @Transactional
-    public Long usePoint(String userId, Long useAmount) {
+    public Long use(String userId, Long useAmount) {
         if (!userRepository.existsByUserId(userId)) {
             throw new CoreException(ErrorType.NOT_FOUND,
                 "[userId = " + userId + "] 해당 유저가 존재하지 않습니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Money.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Money.java
@@ -32,6 +32,15 @@ public class Money {
         return new Money(BigDecimal.valueOf(value));
     }
 
+    public Money subtract(Money other) {
+        if (other == null) {
+            return this;
+        }
+
+        BigDecimal result = this.value.subtract(other.value);
+        return Money.of(result);
+    }
+
     public BigDecimal getValue() {
         return value;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -2,12 +2,15 @@ package com.loopers.domain.product;
 
 import com.loopers.application.product.ProductSortOption;
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepository {
 
     Product save(Product product);
 
-    Product findById(Long id);
+    Optional<Product> findById(Long id);
+
+    Optional<Product> findByIdWithLock(Long id);
 
     boolean existsById(Long id);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -26,7 +26,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public Product findById(Long id) {
+    public Product get(Long id) {
         return productRepository.findById(id)
             .orElseThrow(() -> new CoreException(
                 ErrorType.NOT_FOUND,
@@ -35,7 +35,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<Product> findProductsWithSortingAndPaging(
+    public List<Product> getAllWithSortingAndPaging(
         ProductSortOption sort,
         int page,
         int size
@@ -53,7 +53,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public long countProducts() {
+    public long count() {
         return productRepository.countAll();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -6,6 +6,7 @@ import com.loopers.support.error.ErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -13,6 +14,7 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
+    @Transactional
     public Product create(
         String name,
         Money price,
@@ -23,19 +25,16 @@ public class ProductService {
         return productRepository.save(product);
     }
 
+    @Transactional(readOnly = true)
     public Product findById(Long id) {
-        Product product = productRepository.findById(id);
-
-        if (product == null) {
-            throw new CoreException(
+        return productRepository.findById(id)
+            .orElseThrow(() -> new CoreException(
                 ErrorType.NOT_FOUND,
                 "상품이 존재하지 않습니다."
-            );
-        }
-
-        return product;
+            ));
     }
 
+    @Transactional(readOnly = true)
     public List<Product> findProductsWithSortingAndPaging(
         ProductSortOption sort,
         int page,
@@ -44,6 +43,16 @@ public class ProductService {
         return productRepository.findAllWithSortingAndPaging(sort, page, size);
     }
 
+    @Transactional
+    public void decreaseStock(Long productId, Quantity quantity) {
+        Product product = productRepository.findByIdWithLock(productId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품이 존재하지 않습니다."));
+
+        product.decreaseStock(quantity);
+        productRepository.save(product);
+    }
+
+    @Transactional(readOnly = true)
     public long countProducts() {
         return productRepository.countAll();
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public User findByUserId(String userId) {
+    public User get(String userId) {
         User user = userRepository.findByUserId(userId);
         if (user == null) {
             throw new CoreException(

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+    Optional<Coupon> findByIdAndUserId(Long id, String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public Optional<Coupon> findById(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Coupon> findByIdAndUserId(Long id, String userId) {
+        return couponJpaRepository.findByIdAndUserId(id, userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,10 +1,23 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 public interface PointJpaRepository extends JpaRepository<Point, String> {
 
     Optional<Point> findByUserId(String userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+        @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+    })
+    @Query("SELECT p FROM Point p WHERE p.userId = :userId")
+    Optional<Point> findByUserIdWithLock(@Param("userId") String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,8 +13,13 @@ public class PointRepositoryImpl implements PointRepository {
     private final PointJpaRepository pointJpaRepository;
 
     @Override
-    public Point findByUserId(String userId) {
-        return pointJpaRepository.findByUserId(userId).orElse(null);
+    public Optional<Point> findByUserId(String userId) {
+        return pointJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<Point> findByUserIdWithLock(String userId) {
+        return pointJpaRepository.findByUserIdWithLock(userId);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,12 +1,25 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.Product;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+        @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+    })
+    @Query("SELECT p FROM Product p WHERE p.id = :id")
+    Optional<Product> findByIdWithLock(@Param("id") Long id);
 
     @Query("""
         SELECT p FROM Product p 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.application.product.ProductSortOption;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,8 +22,13 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Product findById(Long id) {
-        return productJpaRepository.findById(id).orElse(null);
+    public Optional<Product> findById(Long id) {
+        return productJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Product> findByIdWithLock(Long id) {
+        return productJpaRepository.findByIdWithLock(id);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -10,12 +10,12 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface PointV1ApiSpec {
 
     @Operation(summary = "포인트 조회")
-    ApiResponse<PointV1Dto.PointResponse> getPoint(
+    ApiResponse<PointV1Dto.PointResponse> get(
         @RequestHeader("X-USER-ID") String userId
     );
 
     @Operation(summary = "포인트 충전")
-    ApiResponse<PointV1Dto.PointResponse> chargePoint(
+    ApiResponse<PointV1Dto.PointResponse> charge(
         @RequestHeader("X-USER-ID") String userId,
         @RequestBody PointV1Dto.ChargeRequest chargeRequest
     );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -23,13 +23,13 @@ public class PointV1Controller implements PointV1ApiSpec{
 
     @GetMapping
     @Override
-    public ApiResponse<PointResponse> getPoint(@RequestHeader ("X-USER-ID") String userId) {
+    public ApiResponse<PointResponse> get(@RequestHeader ("X-USER-ID") String userId) {
 
         if (userId == null || userId.trim().isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 값이 비어있습니다.");
         }
 
-        Long amount = pointService.getPointAmount(userId);
+        Long amount = pointService.getAmount(userId);
 
         if (amount == null) {
             throw new CoreException(ErrorType.NOT_FOUND,
@@ -41,7 +41,7 @@ public class PointV1Controller implements PointV1ApiSpec{
 
     @PostMapping
     @Override
-    public ApiResponse<PointResponse> chargePoint(
+    public ApiResponse<PointResponse> charge(
         @RequestHeader("X-USER-ID") String userId,
         @RequestBody ChargeRequest chargeRequest
     ) {
@@ -49,7 +49,7 @@ public class PointV1Controller implements PointV1ApiSpec{
             throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 값이 비어있습니다.");
         }
 
-        Long totalAmount = pointService.chargePoint(userId, chargeRequest.amount());
+        Long totalAmount = pointService.charge(userId, chargeRequest.amount());
         return ApiResponse.success(new PointResponse(totalAmount));
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -13,7 +13,7 @@ public interface UserV1ApiSpec {
     );
 
     @Operation(summary = "내 정보 조회")
-    ApiResponse<UserV1Dto.UserResponse> findUser(
+    ApiResponse<UserV1Dto.UserResponse> get(
         String userId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -45,8 +45,8 @@ public class UserV1Controller implements UserV1ApiSpec{
 
     @Override
     @GetMapping("/{userId}")
-    public ApiResponse<UserResponse> findUser(@PathVariable String userId) {
-        User user = userService.findByUserId(userId);
+    public ApiResponse<UserResponse> get(@PathVariable String userId) {
+        User user = userService.get(userId);
 
         if (user == null) {
             throw new CoreException(ErrorType.NOT_FOUND,

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
@@ -106,9 +106,9 @@ public class LikeFacadeIntegrationTest {
             // then
             verify(userRepository, times(1)).findByUserId(userId);
             verify(productRepository, times(1)).findById(product.getId());
-            verify(likeService, times(1)).isLikedByUser(userId, product.getId());
-            verify(likeService, times(1)).create(userId, product.getId());
-            verify(likeService, times(1)).countLikesByProduct(product.getId());
+            verify(likeService, times(1)).isLiked(userId, product.getId());
+            verify(likeService, times(1)).like(userId, product.getId());
+            verify(likeService, times(1)).countByProduct(product.getId());
 
             assertAll(
                 () -> assertThat(result).isNotNull(),
@@ -147,9 +147,9 @@ public class LikeFacadeIntegrationTest {
             LikeInfo.Like result = likeFacade.addLike(command);
 
             // then
-            verify(likeService, times(2)).isLikedByUser(userId, product.getId());
-            verify(likeService, times(1)).create(userId, product.getId());
-            verify(likeService, times(2)).countLikesByProduct(product.getId());
+            verify(likeService, times(2)).isLiked(userId, product.getId());
+            verify(likeService, times(1)).like(userId, product.getId());
+            verify(likeService, times(2)).countByProduct(product.getId());
 
             assertAll(
                 () -> assertThat(result).isNotNull(),
@@ -185,7 +185,7 @@ public class LikeFacadeIntegrationTest {
                 });
 
             verify(userRepository, times(1)).findByUserId(nonExistentUserId);
-            verify(likeService, never()).create(anyString(), anyLong());
+            verify(likeService, never()).like(anyString(), anyLong());
         }
 
         @Test
@@ -216,7 +216,7 @@ public class LikeFacadeIntegrationTest {
 
             verify(userRepository, times(1)).findByUserId(userId);
             verify(productRepository, times(1)).findById(nonExistentProductId);
-            verify(likeService, never()).create(anyString(), anyLong());
+            verify(likeService, never()).like(anyString(), anyLong());
         }
     }
 
@@ -255,7 +255,7 @@ public class LikeFacadeIntegrationTest {
             LikeInfo.Like result = likeFacade.removeLike(removeCommand);
 
             // then
-            verify(likeService, times(1)).delete(userId, product.getId());
+            verify(likeService, times(1)).unlike(userId, product.getId());
 
             assertAll(
                 () -> assertThat(result).isNotNull(),
@@ -293,9 +293,9 @@ public class LikeFacadeIntegrationTest {
             LikeInfo.Like result = likeFacade.removeLike(command);
 
             // then
-            verify(likeService, times(1)).isLikedByUser(userId, product.getId());
-            verify(likeService, never()).delete(userId, product.getId());
-            verify(likeService, times(1)).countLikesByProduct(product.getId());
+            verify(likeService, times(1)).isLiked(userId, product.getId());
+            verify(likeService, never()).unlike(userId, product.getId());
+            verify(likeService, times(1)).countByProduct(product.getId());
 
             assertAll(
                 () -> assertThat(result).isNotNull(),
@@ -331,7 +331,7 @@ public class LikeFacadeIntegrationTest {
                 });
 
             verify(userRepository, times(1)).findByUserId(nonExistentUserId);
-            verify(likeService, never()).delete(anyString(), anyLong());
+            verify(likeService, never()).unlike(anyString(), anyLong());
         }
 
         @Test
@@ -362,7 +362,7 @@ public class LikeFacadeIntegrationTest {
 
             verify(userRepository, times(1)).findByUserId(userId);
             verify(productRepository, times(1)).findById(nonExistentProductId);
-            verify(likeService, never()).delete(anyString(), anyLong());
+            verify(likeService, never()).unlike(anyString(), anyLong());
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -108,7 +108,7 @@ public class OrderFacadeIntegrationTest {
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
 
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
@@ -157,7 +157,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
@@ -182,7 +182,7 @@ public class OrderFacadeIntegrationTest {
 
             // then
             verify(userRepository, times(1)).findByUserId(userId);
-            verify(couponService, times(1)).getUserCoupon(savedCoupon.getId(), userId);
+            verify(couponService, times(1)).get(savedCoupon.getId(), userId);
             verify(orderRepository, times(2)).save(any());
 
             assertAll(
@@ -200,7 +200,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(1), brand1.getId());
@@ -230,7 +230,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 5000L);
+            pointService.charge(userId, 5000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
@@ -283,7 +283,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Long nonExistentProductId = 999L;
             List<OrderItemCommand.Create> items = List.of(
@@ -311,7 +311,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
@@ -333,7 +333,7 @@ public class OrderFacadeIntegrationTest {
                 });
 
             verify(userRepository, times(1)).findByUserId(userId);
-            verify(couponService, times(1)).getUserCoupon(nonExistentCouponId, userId);
+            verify(couponService, times(1)).get(nonExistentCouponId, userId);
         }
     }
 
@@ -347,7 +347,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 50000L);
+            pointService.charge(userId, 50000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
@@ -389,7 +389,7 @@ public class OrderFacadeIntegrationTest {
             // given
             String userId = "user1";
             userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
-            pointService.chargePoint(userId, 100000L);
+            pointService.charge(userId, 100000L);
 
             Brand brand1 = brandService.create("brand1", "description1");
             Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -10,6 +10,11 @@ import static org.mockito.Mockito.verify;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.coupon.DiscountAmount;
+import com.loopers.domain.coupon.FixedAmountCoupon;
 import com.loopers.domain.order.OrderRepository;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.order.OrderStatus;
@@ -27,6 +32,8 @@ import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +62,9 @@ public class OrderFacadeIntegrationTest {
     @Autowired
     private PointService pointService;
 
+    @Autowired
+    private CouponRepository couponRepository;
+
     @MockitoSpyBean
     private OrderService orderService;
 
@@ -75,6 +85,9 @@ public class OrderFacadeIntegrationTest {
 
     @MockitoSpyBean
     private ExternalOrderService externalOrderService;
+
+    @MockitoSpyBean
+    private CouponService couponService;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -106,7 +119,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(product2.getId(), Quantity.of(1))
             );
 
-            OrderCommand.Create command = new OrderCommand.Create(userId, items);
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, null);
 
             // when
             OrderInfo.Detail result = orderFacade.createOrder(command);
@@ -139,6 +152,49 @@ public class OrderFacadeIntegrationTest {
         }
 
         @Test
+        @DisplayName("쿠폰 적용하여 주문 생성이 성공한다")
+        void createOrder_withCoupon() {
+            // given
+            String userId = "user1";
+            userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
+            pointService.chargePoint(userId, 50000L);
+
+            Brand brand1 = brandService.create("brand1", "description1");
+            Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "1000원 할인 쿠폰",
+                userId,
+                DiscountAmount.of(BigDecimal.valueOf(1000)),
+                Money.of(5000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Coupon savedCoupon = couponRepository.save(coupon);
+
+            List<OrderItemCommand.Create> items = List.of(
+                new OrderItemCommand.Create(product1.getId(), Quantity.of(1))
+            );
+
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, savedCoupon.getId());
+
+            // when
+            OrderInfo.Detail result = orderFacade.createOrder(command);
+
+            // then
+            verify(userRepository, times(1)).findByUserId(userId);
+            verify(couponService, times(1)).getUserCoupon(savedCoupon.getId(), userId);
+            verify(orderRepository, times(2)).save(any());
+
+            assertAll(
+                () -> assertThat(result).isNotNull(),
+                () -> assertThat(result.userId()).isEqualTo(userId),
+                () -> assertThat(result.totalPrice()).isEqualTo(Money.of(10000L)),
+                () -> assertThat(result.status()).isEqualTo(OrderStatus.COMPLETED),
+                () -> assertThat(result.items()).hasSize(1)
+            );
+        }
+
+        @Test
         @DisplayName("재고가 부족할 때 주문 생성이 실패한다")
         void fail_whenStockInsufficient() {
             // given
@@ -153,7 +209,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(product1.getId(), Quantity.of(2))
             );
 
-            OrderCommand.Create command = new OrderCommand.Create(userId, items);
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, null);
 
             // when & then
             assertThatThrownBy(() -> orderFacade.createOrder(command))
@@ -183,7 +239,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(product1.getId(), Quantity.of(1))
             );
 
-            OrderCommand.Create command = new OrderCommand.Create(userId, items);
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, null);
 
             // when & then
             assertThatThrownBy(() -> orderFacade.createOrder(command))
@@ -207,7 +263,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(product1.getId(), Quantity.of(1))
             );
 
-            OrderCommand.Create command = new OrderCommand.Create(nonExistentUserId, items);
+            OrderCommand.Create command = new OrderCommand.Create(nonExistentUserId, items, null);
 
             // when & then
             assertThatThrownBy(() -> orderFacade.createOrder(command))
@@ -234,7 +290,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(nonExistentProductId, Quantity.of(1))
             );
 
-            OrderCommand.Create command = new OrderCommand.Create(userId, items);
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, null);
 
             // when & then
             assertThatThrownBy(() -> orderFacade.createOrder(command))
@@ -247,6 +303,37 @@ public class OrderFacadeIntegrationTest {
 
             verify(userRepository, times(1)).findByUserId(userId);
             verify(productRepository, times(1)).findById(nonExistentProductId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 쿠폰으로 주문 생성 시 실패한다")
+        void fail_whenCouponNotExists() {
+            // given
+            String userId = "user1";
+            userService.signUp(userId, "사용자1", Gender.M, "abc@gmail.com", "1995-03-01");
+            pointService.chargePoint(userId, 50000L);
+
+            Brand brand1 = brandService.create("brand1", "description1");
+            Product product1 = productService.create("product1", Money.of(10000L), Quantity.of(100), brand1.getId());
+
+            List<OrderItemCommand.Create> items = List.of(
+                new OrderItemCommand.Create(product1.getId(), Quantity.of(1))
+            );
+
+            Long nonExistentCouponId = 999L;
+            OrderCommand.Create command = new OrderCommand.Create(userId, items, nonExistentCouponId);
+
+            // when & then
+            assertThatThrownBy(() -> orderFacade.createOrder(command))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+                    assertThat(coreException.getMessage()).contains("쿠폰을 찾을 수 없습니다");
+                });
+
+            verify(userRepository, times(1)).findByUserId(userId);
+            verify(couponService, times(1)).getUserCoupon(nonExistentCouponId, userId);
         }
     }
 
@@ -269,7 +356,7 @@ public class OrderFacadeIntegrationTest {
                 new OrderItemCommand.Create(product1.getId(), Quantity.of(2))
             );
 
-            OrderCommand.Create createCommand = new OrderCommand.Create(userId, items);
+            OrderCommand.Create createCommand = new OrderCommand.Create(userId, items, null);
             OrderInfo.Detail createdOrder = orderFacade.createOrder(createCommand);
 
             OrderCommand.GetDetail command = new OrderCommand.GetDetail(createdOrder.orderId(), userId);
@@ -310,9 +397,9 @@ public class OrderFacadeIntegrationTest {
 
             // 2개 주문 생성
             OrderCommand.Create createCommand1 = new OrderCommand.Create(userId,
-                List.of(new OrderItemCommand.Create(product1.getId(), Quantity.of(1))));
+                List.of(new OrderItemCommand.Create(product1.getId(), Quantity.of(1))), null);
             OrderCommand.Create createCommand2 = new OrderCommand.Create(userId,
-                List.of(new OrderItemCommand.Create(product2.getId(), Quantity.of(2))));
+                List.of(new OrderItemCommand.Create(product2.getId(), Quantity.of(2))), null);
 
             orderFacade.createOrder(createCommand1);
             orderFacade.createOrder(createCommand2);

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -95,7 +95,7 @@ public class ProductFacadeIntegrationTest {
                 "1995-03-01"
             );
 
-            likeService.create(userId, product.getId());
+            likeService.like(userId, product.getId());
 
             ProductCommand.GetDetail command = ProductCommand.GetDetail.of(product.getId());
 
@@ -285,8 +285,8 @@ public class ProductFacadeIntegrationTest {
                 "1995-03-01"
             );
 
-            likeService.create(userId, product1.getId());
-            likeService.create(userId, product2.getId());
+            likeService.like(userId, product1.getId());
+            likeService.like(userId, product2.getId());
 
             ProductCommand.GetLikedProducts command = ProductCommand.GetLikedProducts.of(userId, 0, 10);
 
@@ -362,7 +362,7 @@ public class ProductFacadeIntegrationTest {
                     Quantity.of(100),
                     brand1.getId()
                 );
-                likeService.create(userId, product.getId());
+                likeService.like(userId, product.getId());
             }
 
             ProductCommand.GetLikedProducts command = ProductCommand.GetLikedProducts.of(userId, 1, 2);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
@@ -102,7 +102,7 @@ class BrandServiceTest {
             when(brandRepository.findById(brandId)).thenReturn(brand);
 
             //when
-            Brand result = brandService.findById(brandId);
+            Brand result = brandService.get(brandId);
 
             //then
             assertThat(result).isEqualTo(brand);
@@ -117,7 +117,7 @@ class BrandServiceTest {
             when(brandRepository.findById(nonExistentId)).thenReturn(null);
 
             //when & then
-            assertThatThrownBy(() -> brandService.findById(nonExistentId))
+            assertThatThrownBy(() -> brandService.get(nonExistentId))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceConcurrencyTest.java
@@ -1,0 +1,89 @@
+package com.loopers.domain.coupon;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.product.Money;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class CouponConcurrencyTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다")
+    @Test
+    void concurrentCouponUsage_onlyOneSucceeds() throws InterruptedException {
+        // given
+        String userId = "user1";
+        FixedAmountCoupon coupon = FixedAmountCoupon.create(
+            "1000원 할인 쿠폰",
+            userId,
+            DiscountAmount.of(BigDecimal.valueOf(1000)),
+            Money.of(BigDecimal.valueOf(5000)),
+            LocalDateTime.now().plusDays(7)
+        );
+        Coupon savedCoupon = couponRepository.save(coupon);
+
+        Money orderAmount = Money.of(BigDecimal.valueOf(10000));
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    couponService.apply(savedCoupon.getId(), userId, orderAmount);
+                    successCount.incrementAndGet();
+                } catch (CoreException e) {
+                    failCount.incrementAndGet();
+                    System.out.println("쿠폰 사용 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Coupon finalCoupon = couponRepository.findByIdAndUserId(savedCoupon.getId(), userId)
+            .orElseThrow();
+
+        assertAll(
+            () -> assertThat(successCount.get()).isEqualTo(1),
+            () -> assertThat(failCount.get()).isGreaterThan(0),
+            () -> assertThat(finalCoupon.getStatus()).isEqualTo(CouponStatus.USED),
+            () -> assertThat(finalCoupon.getUsedAt()).isNotNull()
+        );
+    }}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
@@ -1,0 +1,222 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.loopers.domain.product.Money;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @DisplayName("쿠폰 적용")
+    @Nested
+    class Apply {
+
+        @DisplayName("정액 할인 쿠폰을 정상적으로 적용한다.")
+        @Test
+        void apply_fixedAmount() {
+            // given
+            Long couponId = 1L;
+            String userId = "user1";
+            Money orderAmount = Money.of(50000);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                userId,
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+
+            when(couponRepository.findByIdAndUserId(couponId, userId))
+                .thenReturn(Optional.of(coupon));
+            when(couponRepository.save(any(Coupon.class)))
+                .thenReturn(coupon);
+
+            // when
+            Money discountAmount = couponService.apply(couponId, userId, orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(5000));
+            assertThat(coupon.getStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(coupon.getUsedAt()).isNotNull();
+
+            verify(couponRepository).findByIdAndUserId(couponId, userId);
+            verify(couponRepository).save(coupon);
+        }
+
+        @DisplayName("정률 할인 쿠폰을 정상적으로 적용한다.")
+        @Test
+        void apply_fixedRate() {
+            // given
+            Long couponId = 1L;
+            String userId = "user1";
+            Money orderAmount = Money.of(50000);
+
+            FixedRateCoupon coupon = FixedRateCoupon.create(
+                "10% 할인 쿠폰",
+                userId,
+                DiscountRate.of(BigDecimal.valueOf(10.0)),
+                Money.of(10000),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+
+            when(couponRepository.findByIdAndUserId(couponId, userId))
+                .thenReturn(Optional.of(coupon));
+            when(couponRepository.save(any(Coupon.class)))
+                .thenReturn(coupon);
+
+            // when
+            Money discountAmount = couponService.apply(couponId, userId, orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(5000));
+            assertThat(coupon.getStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(coupon.getUsedAt()).isNotNull();
+
+            verify(couponRepository).findByIdAndUserId(couponId, userId);
+            verify(couponRepository).save(coupon);
+        }
+
+        @DisplayName("정률 할인 쿠폰의 최대 할인 금액이 적용된다.")
+        @Test
+        void apply_fixedRate_withMaxLimit() {
+            // given
+            Long couponId = 1L;
+            String userId = "user1";
+            Money orderAmount = Money.of(100000);
+
+            FixedRateCoupon coupon = FixedRateCoupon.create(
+                "10% 할인 쿠폰", userId,
+                DiscountRate.of(BigDecimal.valueOf(10.0)),
+                Money.of(5000),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+
+            when(couponRepository.findByIdAndUserId(couponId, userId))
+                .thenReturn(Optional.of(coupon));
+            when(couponRepository.save(any(Coupon.class)))
+                .thenReturn(coupon);
+
+            // when
+            Money discountAmount = couponService.apply(couponId, userId, orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(5000));
+            assertThat(coupon.getStatus()).isEqualTo(CouponStatus.USED);
+
+            verify(couponRepository).findByIdAndUserId(couponId, userId);
+            verify(couponRepository).save(coupon);
+        }
+
+        @DisplayName("존재하지 않는 쿠폰으로 요청시 예외가 발생한다.")
+        @Test
+        void fail_whenCouponNotExists() {
+            // given
+            Long nonExistentCouponId = 999L;
+            String userId = "user1";
+            Money orderAmount = Money.of(50000);
+
+            when(couponRepository.findByIdAndUserId(nonExistentCouponId, userId))
+                .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> couponService.apply(nonExistentCouponId, userId, orderAmount))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+                    assertThat(coreException.getMessage()).isEqualTo("사용자의 쿠폰을 찾을 수 없습니다.");
+                });
+
+            verify(couponRepository).findByIdAndUserId(nonExistentCouponId, userId);
+        }
+
+        @DisplayName("이미 사용된 쿠폰으로 요청시 예외가 발생한다.")
+        @Test
+        void fail_whenCouponAlreadyUsed() {
+            // given
+            Long couponId = 1L;
+            String userId = "user1";
+            Money orderAmount = Money.of(50000);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                userId,
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            coupon.use(orderAmount);
+
+            when(couponRepository.findByIdAndUserId(couponId, userId))
+                .thenReturn(Optional.of(coupon));
+
+            // when & then
+            assertThatThrownBy(() -> couponService.apply(couponId, userId, orderAmount))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).isEqualTo("이미 사용된 쿠폰입니다.");
+                });
+
+            verify(couponRepository).findByIdAndUserId(couponId, userId);
+        }
+
+        @DisplayName("최소 주문 금액 미달시 예외가 발생한다.")
+        @Test
+        void fail_whenOrderAmountBelowMinimum() {
+            // given
+            Long couponId = 1L;
+            String userId = "user1";
+            Money orderAmount = Money.of(20000);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                userId,
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+
+            when(couponRepository.findByIdAndUserId(couponId, userId))
+                .thenReturn(Optional.of(coupon));
+
+            // when & then
+            assertThatThrownBy(() -> couponService.apply(couponId, userId, orderAmount))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).contains("최소 주문 금액");
+                    assertThat(coreException.getMessage()).contains("30000");
+                });
+
+            verify(couponRepository).findByIdAndUserId(couponId, userId);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -1,0 +1,308 @@
+package com.loopers.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.product.Money;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponTest {
+
+    @DisplayName("정액 할인 쿠폰 생성")
+    @Nested
+    class CreateFixedAmount {
+
+        @DisplayName("정액 할인 쿠폰을 생성한다.")
+        @Test
+        void create() {
+            // given
+            String name = "5000원 할인 쿠폰";
+            String userId = "user1";
+            DiscountAmount discountAmount = DiscountAmount.of(BigDecimal.valueOf(5000));
+            Money minOrderAmount = Money.of(30000);
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
+            // when
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                name,
+                userId,
+                discountAmount,
+                minOrderAmount,
+                expiredAt
+            );
+
+            // then
+            assertAll(
+                () -> assertThat(coupon.getId()).isNull(),
+                () -> assertThat(coupon.getName()).isEqualTo(name),
+                () -> assertThat(coupon.getUserId()).isEqualTo(userId),
+                () -> assertThat(coupon.getDiscountAmount()).isEqualTo(discountAmount),
+                () -> assertThat(coupon.getMinOrderAmount()).isEqualTo(minOrderAmount),
+                () -> assertThat(coupon.getStatus()).isEqualTo(CouponStatus.ACTIVE),
+                () -> assertThat(coupon.getType()).isEqualTo(CouponType.FIXED_AMOUNT),
+                () -> assertThat(coupon.getExpiredAt()).isEqualTo(expiredAt),
+                () -> assertThat(coupon.getUsedAt()).isNull()
+            );
+        }
+
+        @DisplayName("쿠폰명이 유효하지 않은 경우 예외를 반환한다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void fail_whenCouponNameIsInvalid(String invalidName) {
+            // given
+            String userId = "user1";
+            DiscountAmount discountAmount = DiscountAmount.of(BigDecimal.valueOf(5000));
+            Money minOrderAmount = Money.of(30000);
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
+            // when & then
+            assertThatThrownBy(() -> FixedAmountCoupon.create(
+                invalidName, userId, discountAmount, minOrderAmount, expiredAt
+            ))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).isEqualTo("쿠폰명은 필수입니다.");
+                });
+        }
+
+        @DisplayName("사용자 ID가 유효하지 않은 경우 예외를 반환한다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void fail_whenUserIdIsInvalid(String invalidUserId) {
+            // given
+            String name = "5000원 할인 쿠폰";
+            DiscountAmount discountAmount = DiscountAmount.of(BigDecimal.valueOf(5000));
+            Money minOrderAmount = Money.of(30000);
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
+            // when & then
+            assertThatThrownBy(() -> FixedAmountCoupon.create(
+                name, invalidUserId, discountAmount, minOrderAmount, expiredAt
+            ))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).isEqualTo("User ID는 필수입니다.");
+                });
+        }
+
+        @DisplayName("만료일이 과거인 경우 예외를 반환한다.")
+        @Test
+        void fail_whenExpiredAtIsPast() {
+            // given
+            String name = "5000원 할인 쿠폰";
+            String userId = "user1";
+            DiscountAmount discountAmount = DiscountAmount.of(BigDecimal.valueOf(5000));
+            Money minOrderAmount = Money.of(30000);
+            LocalDateTime pastExpiredAt = LocalDateTime.now().minusDays(1);
+
+            // when & then
+            assertThatThrownBy(() -> FixedAmountCoupon.create(
+                name, userId, discountAmount, minOrderAmount, pastExpiredAt
+            ))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).isEqualTo("만료일은 현재 시간 이후여야 합니다.");
+                });
+        }
+    }
+
+    @DisplayName("정률 할인 쿠폰 생성")
+    @Nested
+    class CreateFixedRate {
+
+        @DisplayName("정률 할인 쿠폰을 생성한다.")
+        @Test
+        void create() {
+            // given
+            String name = "10% 할인 쿠폰";
+            String userId = "user1";
+            DiscountRate discountRate = DiscountRate.of(BigDecimal.valueOf(10.0));
+            Money maxDiscountAmount = Money.of(5000);
+            Money minOrderAmount = Money.of(30000);
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
+            // when
+            FixedRateCoupon coupon = FixedRateCoupon.create(
+                name,
+                userId,
+                discountRate,
+                maxDiscountAmount,
+                minOrderAmount,
+                expiredAt
+            );
+
+            // then
+            assertAll(
+                () -> assertThat(coupon.getId()).isNull(),
+                () -> assertThat(coupon.getName()).isEqualTo(name),
+                () -> assertThat(coupon.getUserId()).isEqualTo(userId),
+                () -> assertThat(coupon.getDiscountRate()).isEqualTo(discountRate),
+                () -> assertThat(coupon.getMaxDiscountAmount()).isEqualTo(maxDiscountAmount),
+                () -> assertThat(coupon.getMinOrderAmount()).isEqualTo(minOrderAmount),
+                () -> assertThat(coupon.getStatus()).isEqualTo(CouponStatus.ACTIVE),
+                () -> assertThat(coupon.getType()).isEqualTo(CouponType.FIXED_RATE),
+                () -> assertThat(coupon.getExpiredAt()).isEqualTo(expiredAt),
+                () -> assertThat(coupon.getUsedAt()).isNull()
+            );
+        }
+    }
+
+    @DisplayName("할인 금액 계산")
+    @Nested
+    class CalculateDiscountAmount {
+
+        @DisplayName("정액 할인 쿠폰의 할인 금액을 계산한다.")
+        @Test
+        void fixedAmount_calculateDiscount() {
+            // given
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                "user1",
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(50000);
+
+            // when
+            Money discountAmount = coupon.calculateDiscountAmount(orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(5000));
+        }
+
+        @DisplayName("정률 할인 쿠폰의 할인 금액을 계산한다.")
+        @Test
+        void fixedRate_calculateDiscount() {
+            // given
+            FixedRateCoupon coupon = FixedRateCoupon.create(
+                "10% 할인 쿠폰",
+                "user1",
+                DiscountRate.of(BigDecimal.valueOf(10.0)),
+                Money.of(10000),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(50000);
+
+            // when
+            Money discountAmount = coupon.calculateDiscountAmount(orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(5000));
+        }
+
+        @DisplayName("정률 할인 쿠폰의 최대 할인 금액을 초과하는 경우 최대 할인 금액을 반환한다.")
+        @Test
+        void fixedRate_calculateDiscount_withMaxLimit() {
+            // given
+            FixedRateCoupon coupon = FixedRateCoupon.create(
+                "10% 할인 쿠폰",
+                "user1",
+                DiscountRate.of(BigDecimal.valueOf(10.0)),
+                Money.of(3000),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(50000);
+
+            // when
+            Money discountAmount = coupon.calculateDiscountAmount(orderAmount);
+
+            // then
+            assertThat(discountAmount).isEqualTo(Money.of(3000));
+        }
+    }
+
+    @DisplayName("쿠폰 사용")
+    @Nested
+    class Use {
+
+        @DisplayName("쿠폰을 정상적으로 사용한다.")
+        @Test
+        void use() {
+            // given
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                "user1",
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(50000);
+
+            // when
+            coupon.use(orderAmount);
+
+            // then
+            assertThat(coupon.getStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(coupon.getUsedAt()).isNotNull();
+        }
+
+        @DisplayName("이미 사용된 쿠폰을 다시 사용하려 하면 예외가 발생한다.")
+        @Test
+        void fail_whenCouponAlreadyUsed() {
+            // given
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                "user1",
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(50000);
+            coupon.use(orderAmount);
+
+            // when & then
+            assertThatThrownBy(() -> coupon.use(orderAmount))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).isEqualTo("이미 사용된 쿠폰입니다.");
+                });
+        }
+
+        @DisplayName("최소 주문 금액 미달시 예외가 발생한다.")
+        @Test
+        void fail_whenOrderAmountBelowMinimum() {
+            // given
+            FixedAmountCoupon coupon = FixedAmountCoupon.create(
+                "5000원 할인 쿠폰",
+                "user1",
+                DiscountAmount.of(BigDecimal.valueOf(5000)),
+                Money.of(30000),
+                LocalDateTime.now().plusDays(7)
+            );
+            Money orderAmount = Money.of(20000); // 최소 주문 금액 미달
+
+            // when & then
+            assertThatThrownBy(() -> coupon.use(orderAmount))
+                .isInstanceOf(CoreException.class)
+                .satisfies(exception -> {
+                    CoreException coreException = (CoreException) exception;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    assertThat(coreException.getMessage()).contains("최소 주문 금액");
+                    assertThat(coreException.getMessage()).contains("30000");
+                });
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceConcurrencyTest.java
@@ -85,7 +85,7 @@ class LikeConcurrencyTest {
             final String userId = "user" + i;
             executorService.submit(() -> {
                 try {
-                    likeService.create(userId, savedProduct.getId());
+                    likeService.like(userId, savedProduct.getId());
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     System.out.println("좋아요 실패: " + e.getMessage());
@@ -99,7 +99,7 @@ class LikeConcurrencyTest {
         executorService.shutdown();
 
         // then
-        long likeCount = likeService.countLikesByProduct(savedProduct.getId());
+        long likeCount = likeService.countByProduct(savedProduct.getId());
 
         assertAll(
             () -> assertThat(likeCount).isEqualTo(userCount),
@@ -135,7 +135,7 @@ class LikeConcurrencyTest {
             userRepository.save(user);
 
             if (i > 10) {
-                likeService.create("user" + i, savedProduct.getId());
+                likeService.like("user" + i, savedProduct.getId());
             }
         }
 
@@ -150,9 +150,9 @@ class LikeConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     if (isLikeOperation) {
-                        likeService.create(userId, savedProduct.getId());
+                        likeService.like(userId, savedProduct.getId());
                     } else {
-                        likeService.delete(userId, savedProduct.getId());
+                        likeService.unlike(userId, savedProduct.getId());
                     }
                 } catch (Exception e) {
                     System.out.println("좋아요/취소 실패: " + e.getMessage());
@@ -166,7 +166,7 @@ class LikeConcurrencyTest {
         executorService.shutdown();
 
         // then
-        long finalLikeCount = likeService.countLikesByProduct(savedProduct.getId());
+        long finalLikeCount = likeService.countByProduct(savedProduct.getId());
 
         assertThat(finalLikeCount).isEqualTo(10);
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceConcurrencyTest.java
@@ -1,0 +1,173 @@
+package com.loopers.domain.like;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.product.Money;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.Quantity;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class LikeConcurrencyTest {
+
+    @Autowired
+    private LikeService likeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("동일한 상품에 대해 여러명이 동시에 좋아요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다")
+    @Test
+    void concurrentLikeFromMultipleUsers_correctCount() throws InterruptedException {
+        // given
+        Brand brand = Brand.create("브랜드", "브랜드 설명");
+        brandRepository.save(brand);
+
+        Product product = Product.create(
+            "상품1",
+            Money.of(BigDecimal.valueOf(10000)),
+            Quantity.of(100),
+            brand.getId()
+        );
+        Product savedProduct = productRepository.save(product);
+
+        int userCount = 10;
+        for (int i = 1; i <= userCount; i++) {
+            User user = new User(
+                "user" + i,
+                "사용자" + i,
+                Gender.M,
+                "user" + i + "@gmail.com",
+                "1995-03-01"
+            );
+            userRepository.save(user);
+        }
+
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 1; i <= threadCount; i++) {
+            final String userId = "user" + i;
+            executorService.submit(() -> {
+                try {
+                    likeService.create(userId, savedProduct.getId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    System.out.println("좋아요 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        long likeCount = likeService.countLikesByProduct(savedProduct.getId());
+
+        assertAll(
+            () -> assertThat(likeCount).isEqualTo(userCount),
+            () -> assertThat(successCount.get()).isEqualTo(userCount)
+        );
+    }
+
+    @DisplayName("동일한 상품에 대해 여러명이 좋아요와 좋아요 취소를 동시에 요청해도, 최종 좋아요 개수가 정확해야 한다")
+    @Test
+    void concurrentLikeAndUnlike_correctFinalCount() throws InterruptedException {
+        // given
+        Brand brand = Brand.create("브랜드", "브랜드 설명");
+        brandRepository.save(brand);
+
+        Product product = Product.create(
+            "테스트 상품",
+            Money.of(BigDecimal.valueOf(10000)),
+            Quantity.of(100),
+            brand.getId()
+        );
+        Product savedProduct = productRepository.save(product);
+
+        // 20명의 사용자 (10명은 좋아요, 10명은 좋아요 취소)
+        int totalUsers = 20;
+        for (int i = 1; i <= totalUsers; i++) {
+            User user = new User(
+                "user" + i,
+                "사용자" + i,
+                Gender.M,
+                "user" + i + "@gmail.com",
+                "1995-03-01"
+            );
+            userRepository.save(user);
+
+            if (i > 10) {
+                likeService.create("user" + i, savedProduct.getId());
+            }
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(totalUsers);
+        CountDownLatch latch = new CountDownLatch(totalUsers);
+
+        // when
+        for (int i = 1; i <= totalUsers; i++) {
+            final String userId = "user" + i;
+            final boolean isLikeOperation = i <= 10; // 1-10: 좋아요, 11-20: 취소
+
+            executorService.submit(() -> {
+                try {
+                    if (isLikeOperation) {
+                        likeService.create(userId, savedProduct.getId());
+                    } else {
+                        likeService.delete(userId, savedProduct.getId());
+                    }
+                } catch (Exception e) {
+                    System.out.println("좋아요/취소 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        long finalLikeCount = likeService.countLikesByProduct(savedProduct.getId());
+
+        assertThat(finalLikeCount).isEqualTo(10);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -40,7 +40,7 @@ class LikeServiceTest {
             when(likeRepository.save(any(Like.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
             //when
-            likeService.create(userId, productId);
+            likeService.like(userId, productId);
 
             //then
             verify(likeRepository).findByUserIdAndProductId(userId, productId);
@@ -58,7 +58,7 @@ class LikeServiceTest {
             when(likeRepository.findByUserIdAndProductId(userId, productId)).thenReturn(existingLike);
 
             //when
-            Like result = likeService.create(userId, productId);
+            Like result = likeService.like(userId, productId);
 
             //then
             assertThat(result).isEqualTo(existingLike);
@@ -79,7 +79,7 @@ class LikeServiceTest {
             Long productId = 1L;
 
             //when
-            likeService.delete(userId, productId);
+            likeService.unlike(userId, productId);
 
             //then
             verify(likeRepository).deleteByUserIdAndProductId(userId, productId);
@@ -103,7 +103,7 @@ class LikeServiceTest {
             when(likeRepository.findByUserId(userId)).thenReturn(likes);
 
             //when
-            List<Like> result = likeService.findLikesByUser(userId);
+            List<Like> result = likeService.getAllByUser(userId);
 
             //then
             assertThat(result).hasSize(2);
@@ -121,7 +121,7 @@ class LikeServiceTest {
             when(likeRepository.countByProductId(productId)).thenReturn(expectedCount);
 
             //when
-            long result = likeService.countLikesByProduct(productId);
+            long result = likeService.countByProduct(productId);
 
             //then
             assertThat(result).isEqualTo(expectedCount);
@@ -138,7 +138,7 @@ class LikeServiceTest {
             when(likeRepository.existsByUserIdAndProductId(userId, productId)).thenReturn(true);
 
             //when
-            boolean result = likeService.isLikedByUser(userId, productId);
+            boolean result = likeService.isLiked(userId, productId);
 
             //then
             assertThat(result).isTrue();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceTest.java
@@ -40,7 +40,7 @@ class OrderServiceTest {
             when(orderRepository.save(order)).thenReturn(order);
 
             //when
-            Order result = orderService.save(order);
+            Order result = orderService.place(order);
 
             //then
             assertThat(result).isEqualTo(order);
@@ -61,7 +61,7 @@ class OrderServiceTest {
             when(orderRepository.findById(orderId)).thenReturn(order);
 
             //when
-            Order result = orderService.findById(orderId);
+            Order result = orderService.get(orderId);
 
             //then
             assertThat(result).isEqualTo(order);
@@ -76,7 +76,7 @@ class OrderServiceTest {
             when(orderRepository.findById(nonExistentId)).thenReturn(null);
 
             //when & then
-            assertThatThrownBy(() -> orderService.findById(nonExistentId))
+            assertThatThrownBy(() -> orderService.get(nonExistentId))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;
@@ -97,7 +97,7 @@ class OrderServiceTest {
             when(orderRepository.findByIdAndUserId(orderId, userId)).thenReturn(order);
 
             //when
-            Order result = orderService.findByIdAndUserId(orderId, userId);
+            Order result = orderService.get(orderId, userId);
 
             //then
             assertThat(result).isEqualTo(order);
@@ -114,7 +114,7 @@ class OrderServiceTest {
             when(orderRepository.findByIdAndUserId(orderId, userId)).thenReturn(null);
 
             //when & then
-            assertThatThrownBy(() -> orderService.findByIdAndUserId(orderId, userId))
+            assertThatThrownBy(() -> orderService.get(orderId, userId))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;
@@ -136,7 +136,7 @@ class OrderServiceTest {
             when(orderRepository.findByUserIdOrderByOrderedAtDesc(userId)).thenReturn(orders);
 
             //when
-            List<Order> result = orderService.findByUserId(userId);
+            List<Order> result = orderService.getAllByUser(userId);
 
             //then
             assertThat(result).hasSize(2);
@@ -152,7 +152,7 @@ class OrderServiceTest {
             when(orderRepository.findByUserIdOrderByOrderedAtDesc(userId)).thenReturn(List.of());
 
             //when
-            List<Order> result = orderService.findByUserId(userId);
+            List<Order> result = orderService.getAllByUser(userId);
 
             //then
             assertThat(result).isEmpty();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceConcurrencyTest.java
@@ -1,0 +1,149 @@
+package com.loopers.domain.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PointServiceConcurrencyTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("동일한 유저가 동시에 포인트를 사용해도 정상적으로 차감되어야 한다")
+    @Test
+    void concurrentPointUsage() throws InterruptedException {
+        // given
+        String userId = "user1";
+
+        User user = new User(
+            userId,
+            "clap",
+            Gender.M,
+            "abc@gmail.com",
+            "1995-03-01"
+        );
+        userRepository.save(user);
+
+        Point point = new Point(userId);
+        point.charge(1000L);
+        pointRepository.save(point);
+
+        int threadCount = 10;
+        Long useAmountPerThread = 50L;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointService.usePoint(userId, useAmountPerThread);
+                    successCount.incrementAndGet();
+                } catch (CoreException e) {
+                    failCount.incrementAndGet();
+                    System.out.println("실패 사유: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Long finalAmount = pointService.getPointAmount(userId);
+        Long expectedAmount = 1000L - (successCount.get() * useAmountPerThread);
+
+        assertAll(
+            () -> assertThat(finalAmount).isEqualTo(expectedAmount),
+            () -> assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount)
+        );
+    }
+
+    @DisplayName("포인트가 부족한 상황에서 동시 사용 시 일관성이 유지되어야 한다")
+    @Test
+    void concurrentPointUsage_whenInsufficientPoint() throws InterruptedException {
+        // given
+        String userId = "user1";
+
+        User user = new User(
+            userId,
+            "clap",
+            Gender.M,
+            "abc@gmail.com",
+            "1995-03-01"
+        );
+        userRepository.save(user);
+
+        Point point = new Point(userId);
+        point.charge(300L);
+        pointRepository.save(point);
+
+        int threadCount = 10;
+        Long useAmountPerThread = 50L;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointService.usePoint(userId, useAmountPerThread);
+                    successCount.incrementAndGet();
+                } catch (CoreException e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Long finalAmount = pointService.getPointAmount(userId);
+
+        assertAll(
+            () -> assertThat(successCount.get()).isEqualTo(6),
+            () -> assertThat(failCount.get()).isEqualTo(4),
+            () -> assertThat(finalAmount).isEqualTo(0L)
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceConcurrencyTest.java
@@ -69,7 +69,7 @@ class PointServiceConcurrencyTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    pointService.usePoint(userId, useAmountPerThread);
+                    pointService.use(userId, useAmountPerThread);
                     successCount.incrementAndGet();
                 } catch (CoreException e) {
                     failCount.incrementAndGet();
@@ -84,7 +84,7 @@ class PointServiceConcurrencyTest {
         executorService.shutdown();
 
         // then
-        Long finalAmount = pointService.getPointAmount(userId);
+        Long finalAmount = pointService.getAmount(userId);
         Long expectedAmount = 1000L - (successCount.get() * useAmountPerThread);
 
         assertAll(
@@ -124,7 +124,7 @@ class PointServiceConcurrencyTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    pointService.usePoint(userId, useAmountPerThread);
+                    pointService.use(userId, useAmountPerThread);
                     successCount.incrementAndGet();
                 } catch (CoreException e) {
                     failCount.incrementAndGet();
@@ -138,7 +138,7 @@ class PointServiceConcurrencyTest {
         executorService.shutdown();
 
         // then
-        Long finalAmount = pointService.getPointAmount(userId);
+        Long finalAmount = pointService.getAmount(userId);
 
         assertAll(
             () -> assertThat(successCount.get()).isEqualTo(6),

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -61,7 +61,7 @@ public class PointServiceIntegrationTest {
             );
 
             //when
-            Long point = pointService.getPointAmount(userId);
+            Long point = pointService.getAmount(userId);
 
             //then
             verify(pointRepository, times(1)).findByUserId(userId);
@@ -75,7 +75,7 @@ public class PointServiceIntegrationTest {
             String userId = "notexist";
 
             //when
-            Long point = pointService.getPointAmount(userId);
+            Long point = pointService.getAmount(userId);
 
             //then
             verify(userRepository, times(1)).existsByUserId(userId);
@@ -96,7 +96,7 @@ public class PointServiceIntegrationTest {
             Long chargeAmount = 1000L;
 
             //when & then
-            assertThatThrownBy(() -> pointService.chargePoint(nonExistentUserId, chargeAmount))
+            assertThatThrownBy(() -> pointService.charge(nonExistentUserId, chargeAmount))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceConcurrencyTest.java
@@ -1,0 +1,144 @@
+package com.loopers.domain.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ProductConcurrencyTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다")
+    @Test
+    void concurrentStockDecrease() throws InterruptedException {
+        // given
+        Brand brand = Brand.create("브랜드", "브랜드 설명");
+        brandRepository.save(brand);
+
+        Product product = Product.create(
+            "상품1",
+            Money.of(BigDecimal.valueOf(10000)),
+            Quantity.of(100),
+            brand.getId()
+        );
+        Product savedProduct = productRepository.save(product);
+
+        int threadCount = 10;
+        int decreaseAmountPerThread = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    productService.decreaseStock(savedProduct.getId(), Quantity.of(decreaseAmountPerThread));
+                    successCount.incrementAndGet();
+                } catch (CoreException e) {
+                    failCount.incrementAndGet();
+                    System.out.println("재고 차감 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Product finalProduct = productService.findById(savedProduct.getId());
+        int expectedStock = 100 - (successCount.get() * decreaseAmountPerThread);
+
+        assertAll(
+            () -> assertThat(finalProduct.getStockQuantity().getValue()).isEqualTo(expectedStock),
+            () -> assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount),
+            () -> assertThat(successCount.get()).isEqualTo(10),
+            () -> assertThat(failCount.get()).isEqualTo(0)
+        );
+    }
+
+    @DisplayName("재고가 부족한 상황에서 동시 차감 시 일관성이 유지되어야 한다")
+    @Test
+    void concurrentStockDecrease_whenInsufficientStock() throws InterruptedException {
+        // given
+        Brand brand = Brand.create("브랜드", "브랜드 설명");
+        brandRepository.save(brand);
+
+        Product product = Product.create(
+            "상품1",
+            Money.of(BigDecimal.valueOf(10000)),
+            Quantity.of(30),
+            brand.getId()
+        );
+        Product savedProduct = productRepository.save(product);
+
+        int threadCount = 10;
+        int decreaseAmountPerThread = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    productService.decreaseStock(savedProduct.getId(), Quantity.of(decreaseAmountPerThread));
+                    successCount.incrementAndGet();
+                } catch (CoreException e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Product finalProduct = productService.findById(savedProduct.getId());
+
+        assertAll(
+            () -> assertThat(successCount.get()).isEqualTo(6),
+            () -> assertThat(failCount.get()).isEqualTo(4),
+            () -> assertThat(finalProduct.getStockQuantity().getValue()).isEqualTo(0),
+            () -> assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount)
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceConcurrencyTest.java
@@ -80,7 +80,7 @@ class ProductConcurrencyTest {
         executorService.shutdown();
 
         // then
-        Product finalProduct = productService.findById(savedProduct.getId());
+        Product finalProduct = productService.get(savedProduct.getId());
         int expectedStock = 100 - (successCount.get() * decreaseAmountPerThread);
 
         assertAll(
@@ -132,7 +132,7 @@ class ProductConcurrencyTest {
         executorService.shutdown();
 
         // then
-        Product finalProduct = productService.findById(savedProduct.getId());
+        Product finalProduct = productService.get(savedProduct.getId());
 
         assertAll(
             () -> assertThat(successCount.get()).isEqualTo(6),

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ class ProductServiceTest {
             //given
             Long productId = 1L;
             Product product = Product.create("Cap", Money.of(10000L), Quantity.of(10), 1L);
-            when(productRepository.findById(productId)).thenReturn(product);
+            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
             //when
             Product result = productService.findById(productId);
@@ -70,7 +71,7 @@ class ProductServiceTest {
         void fail_whenProductNotExists() {
             //given
             Long nonExistentId = 999L;
-            when(productRepository.findById(nonExistentId)).thenReturn(null);
+            when(productRepository.findById(nonExistentId)).thenReturn(Optional.empty());
 
             //when & then
             assertThatThrownBy(() -> productService.findById(nonExistentId))

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -59,7 +59,7 @@ class ProductServiceTest {
             when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
             //when
-            Product result = productService.findById(productId);
+            Product result = productService.get(productId);
 
             //then
             assertThat(result).isEqualTo(product);
@@ -74,7 +74,7 @@ class ProductServiceTest {
             when(productRepository.findById(nonExistentId)).thenReturn(Optional.empty());
 
             //when & then
-            assertThatThrownBy(() -> productService.findById(nonExistentId))
+            assertThatThrownBy(() -> productService.get(nonExistentId))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -108,7 +108,7 @@ public class UserServiceIntegrationTest {
             userService.signUp(userId, name, gender, email, birth);
 
             //when
-            User result = userService.findByUserId(userId);
+            User result = userService.get(userId);
 
             //then
             verify(userRepository, times(1)).findByUserId(userId);
@@ -129,7 +129,7 @@ public class UserServiceIntegrationTest {
             String nonExistentUserId = "notfound";
 
             //when & then
-            assertThatThrownBy(() -> userService.findByUserId(nonExistentUserId))
+            assertThatThrownBy(() -> userService.get(nonExistentUserId))
                 .isInstanceOf(CoreException.class)
                 .satisfies(exception -> {
                     CoreException coreException = (CoreException) exception;

--- a/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
+++ b/modules/jpa/src/testFixtures/java/com/loopers/utils/DatabaseCleanUp.java
@@ -4,12 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
 public class DatabaseCleanUp implements InitializingBean {
@@ -23,6 +22,7 @@ public class DatabaseCleanUp implements InitializingBean {
     public void afterPropertiesSet() {
         entityManager.getMetamodel().getEntities().stream()
             .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
+            .filter(entity -> entity.getJavaType().getAnnotation(Table.class) != null)
             .map(entity -> entity.getJavaType().getAnnotation(Table.class).name())
             .forEach(tableNames::add);
     }


### PR DESCRIPTION
## 📌 Summary

- 쿠폰 도메인 
- 주문에 쿠폰 적용 기능 추가
- 재고/포인트/쿠폰 동시성 처리

## 💬 Review Points

1. 이러한 판단기준을 가지고 동시성 처리를 구현했습니다. 적절한 판단기준인지 평가해주시면 감사하겠습니다.

**좋아요 -  동시성 처리 X**

likeCount 필드를 가지고 있지 않기 때문에, 
동시성 제어가 필요하지 않다고 판단해서 따로 동시성 처리를 하진 않았습니다.

**포인트 - 비관적 락**

일단 포인트는 민감한 부분이라고 생각해서 비관적 락을 적용해야겠다고 생각했습니다.
`동일 사용자가 서로 다른 주문을 동시에 수행해도 포인트가 정상적으로 차감되어야 한다.`
또한 이 요구사항도 완벽히 만족하려면 비관적 락을 쓰는게 맞다고 생각했습니다.

**재고 - 비관적 락**
재고도 포인트와 마찬가지고 비즈니스적으로 중요한 부분이기 때문에 비관적 락을 적용했습니다.
또한 다중 사용자 경합 상황이기 때문에, 비관적 락을 적용하는게 맞다고 생각했습니다.

**쿠폰 - 낙관적 락**
쿠폰은 사용자별 소유하는 것이고, 한번 사용하면 끝입니다.
그래서 동일 사용자가 동시에 요청했을 때, 하나만 성공해도 문제가 전혀 없을 것이라고 판단해서 낙관적 락을 적용했습니다.

<br/>

2. 동시성 처리에 대한 테스트가 잘 작성되었는지 궁금합니다.


## ✅ Checklist

### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.